### PR TITLE
feat(daemon): add accounts_status RPC endpoint

### DIFF
--- a/sigilforge-daemon/src/api/server.rs
+++ b/sigilforge-daemon/src/api/server.rs
@@ -285,6 +285,12 @@ async fn process_request(
                 Err(ErrorObject::owned(-32602, "Invalid params", None::<()>))
             }
         }
+        "accounts_status" => {
+            match api.accounts_status().await {
+                Ok(resp) => Ok(serde_json::to_value(resp).unwrap()),
+                Err(e) => Err(e),
+            }
+        }
         _ => Err(ErrorObject::owned(-32601, "Method not found", None::<()>)),
     };
 


### PR DESCRIPTION
## Summary

Add `accounts_status` RPC method for status bar plugins (scarab-sigilforge).

Returns token validity and expiry information for all accounts:
- `token_valid`: whether a valid token exists
- `expires_soon`: whether token expires within 24 hours  
- `expires_at`: optional expiry timestamp

Response includes aggregate flags:
- `all_valid`: true if all accounts have valid tokens
- `any_expiring_soon`: true if any token expires within 24 hours

## Test plan

- [ ] Call `accounts_status` RPC method with configured accounts
- [ ] Verify response structure matches `AccountsStatusResponse`
- [ ] Verify tokens near expiry are flagged as `expires_soon`

## Related

- #38 - scarab-sigilforge plugin (uses this endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)